### PR TITLE
Fix MCP server Context import and bump version to 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-rag-librarian"
-version = "0.2.3"
+version = "0.2.4"
 description = "MCP server for RAG (Retrieval-Augmented Generation) operations with local document indexing - Fork with enhancements"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/rag_mcp_server/server.py
+++ b/src/rag_mcp_server/server.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Union
 
 from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.server import Context
+from mcp.server.fastmcp import Context
 
 # SOLID architecture components
 from .core.service_container import service_container


### PR DESCRIPTION
## Summary
Fix schema validation error "resultSchema.parse is not a function" by correcting the Context import path in the MCP server implementation.

## Problem
The MCP server was failing with a schema validation error due to an incorrect import path for the `Context` class. The import was trying to access `Context` from `mcp.server.fastmcp.server` when it should be imported directly from `mcp.server.fastmcp`.

## Solution
- **Fixed Context import**: Changed from `from mcp.server.fastmcp.server import Context` to `from mcp.server.fastmcp import Context`
- **Version bump**: Updated version from 0.2.3 to 0.2.4 in `pyproject.toml` to reflect this bug fix

## Changes
- `src/rag_mcp_server/server.py`: Fixed Context import statement
- `pyproject.toml`: Bumped version to 0.2.4

## Testing
✅ Verified that the MCP server starts without errors  
✅ Confirmed that MCP client can successfully:
- Connect to the server
- List available tools  
- Initialize knowledge base
- Perform semantic search

## Impact
- **Risk Level**: LOW - Simple import path correction
- **Breaking Changes**: None
- **Dependencies**: No new dependencies

## Commit Hash
c8d7ac0

🤖 Generated with [Claude Code](https://claude.ai/code)